### PR TITLE
add available moves

### DIFF
--- a/assemblyEngine.py
+++ b/assemblyEngine.py
@@ -41,7 +41,7 @@ class Engine:
 
         self.validMoves = self.currentAssembly.getMoves(self.system)
 
-    def step(self):
+    def step(self, nextMove=None):
         if(self.currentIndex < self.lastIndex): 
             move = self.moveList[self.currentIndex]
             self.currentAssembly = self.currentAssembly.performMove(move)
@@ -49,7 +49,7 @@ class Engine:
             self.currentIndex = self.currentIndex + 1
             return 0
         else:
-            return self.build()
+            return self.build(nextMove)
                 
     def back(self):
         if(self.currentIndex > 0): 
@@ -72,7 +72,7 @@ class Engine:
     def getCurrentIndex(self):
         return self.currentIndex
 
-    def build(self):
+    def build(self, nextMove=None):
         # Get current Assembly
         cAssembly = self.getCurrentAssembly()
         #moveList = cAssembly.getMoves(self.system)
@@ -93,7 +93,12 @@ class Engine:
         self.currentIndex = self.currentIndex + 1
 
         # Get next assembly and add to list
-        move = random.choice(self.validMoves)
+        # If given a move, choose that one, otherwise do random move
+        move = None
+        if nextMove == None:
+            move = random.choice(self.validMoves)
+        else:
+            move = nextMove
 
         self.currentAssembly = cAssembly.performMove(move)
         self.moveList.append(move)

--- a/general_TA_simulator.py
+++ b/general_TA_simulator.py
@@ -1,9 +1,8 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QApplication, QMainWindow, QFileDialog, QWidget, QGridLayout
+from PyQt5.QtWidgets import QApplication, QMainWindow, QFileDialog, QWidget, QGridLayout, QVBoxLayout
 from PyQt5.QtGui import QPainter, QBrush, QPen, QColor, QFont
 
-
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 from random import randrange
 
 from assemblyEngine import Engine
@@ -43,12 +42,12 @@ currentAssemblyHistory = []
 # Keep growing until their are no more rules that apply
 
 class Move(QWidget):
-    def __init__(self, text):
+    def __init__(self, move):
         super().__init__()
-        self.initUI(text)
+        self.initUI(move)
     
-    def initUI(self, text):
-        self.text = text
+    def initUI(self, move):
+        self.move = move
         self.show()
     
     def paintEvent(self, event):
@@ -58,12 +57,27 @@ class Move(QWidget):
         qp.end()
     
     def draw(self, event, qp):
-        qp.setPen(QColor(255, 255, 255))
-        qp.setFont(QFont("Times", 10))
-        qp.drawText(event.rect(), Qt.AlignCenter, self.text)
+        moveText = ""
+
+        if self.move["type"] == "a":
+            moveText = "Attach\n" +  self.move["state1"].get_label() + " at " + str(self.move["x"]) + " , " + str(self.move["y"])
+        elif self.move["type"] == "t":
+            moveText = "Transition\n" + self.move["state1"].get_label() + ", " + self.move["state2"].get_label() + " to " + self.move["state1Final"].get_label() + ", " + self.move["state2Final"].get_label()
+
+        qp.setPen(QColor(255,255,255))
+        qp.setFont(QFont("Times", 12))
+        qp.drawText(event.rect(), Qt.AlignCenter, moveText)
+        qp.drawRect(event.rect())
     
     def mousePressEvent(self, event):
         print("clicked on move")
+    
+    # def printMove(move):
+    # if move["type"] == "a":
+    #     print("Attach: ", move["state1"].get_label(), " at ", move["x"], ", ", move["y"])
+    # if move["type"] == "t":
+    #     print("Transition ", move["state1"].get_label(), ", ", move["state2"].get_label(), " to ", move["state1Final"].get_label(), ", ", move["state2Final"].get_label())
+    #     print(" at ", move["x"], ", ", move["y"])
 
 class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
     def __init__(self):
@@ -156,7 +170,8 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
         self.SlowMode_button.clicked.connect(self.slowMode_toggle)
 
         # Available moves layout to place available moves
-        self.movesLayout = QGridLayout(self.page_3)
+        self.movesLayout = QVBoxLayout(self.page_3)
+        self.movesLayout.setAlignment(Qt.AlignmentFlag.AlignTop)
         # List of Move Widgets
         self.moveWidgets = []
 
@@ -387,12 +402,11 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
         self.moveWidgets = []
 
         # Create moves and add to layout
-        i = 0
         for m in self.Engine.validMoves:
-            mGUI = Move(m["type"] + " " + m["state1"].get_label())
+            mGUI = Move(m)
+            mGUI.setFixedHeight(28)
             self.moveWidgets.append(mGUI)
-            self.movesLayout.addWidget(mGUI, i, 0)
-            i += 1
+            self.movesLayout.addWidget(mGUI)
 
         # print(self.Engine.currentIndex)
         self.update()

--- a/general_TA_simulator.py
+++ b/general_TA_simulator.py
@@ -1,6 +1,6 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QApplication, QMainWindow, QFileDialog
-from PyQt5.QtGui import QPainter, QBrush, QPen
+from PyQt5.QtWidgets import QApplication, QMainWindow, QFileDialog, QWidget, QGridLayout
+from PyQt5.QtGui import QPainter, QBrush, QPen, QColor, QFont
 
 
 from PyQt5.QtCore import Qt
@@ -41,6 +41,29 @@ currentAssemblyHistory = []
 # GUI showing step by step growth starting with seed state
 # Step button
 # Keep growing until their are no more rules that apply
+
+class Move(QWidget):
+    def __init__(self, text):
+        super().__init__()
+        self.initUI(text)
+    
+    def initUI(self, text):
+        self.text = text
+        self.show()
+    
+    def paintEvent(self, event):
+        qp = QPainter()
+        qp.begin(self)
+        self.draw(event, qp)
+        qp.end()
+    
+    def draw(self, event, qp):
+        qp.setPen(QColor(255, 255, 255))
+        qp.setFont(QFont("Times", 10))
+        qp.drawText(event.rect(), Qt.AlignCenter, self.text)
+    
+    def mousePressEvent(self, event):
+        print("clicked on move")
 
 class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
     def __init__(self):
@@ -131,6 +154,11 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
         self.Y_reflect_button.clicked.connect(self.Click_YReflect)
 
         self.SlowMode_button.clicked.connect(self.slowMode_toggle)
+
+        # Available moves layout to place available moves
+        self.movesLayout = QGridLayout(self.page_3)
+        # List of Move Widgets
+        self.moveWidgets = []
 
         # Function to Move window on mouse drag event on the title bar
         def moveWindow(e):
@@ -352,6 +380,19 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
         else:
             self.label_2.setText("Time elapsed: \n 0 time steps")
             self.label_3.setText("Current step time: \n 0 time steps")
+
+        # Remove old moves from the layout
+        for m in self.moveWidgets:
+            m.deleteLater()
+        self.moveWidgets = []
+
+        # Create moves and add to layout
+        i = 0
+        for m in self.Engine.validMoves:
+            mGUI = Move(m["type"] + " " + m["state1"].get_label())
+            self.moveWidgets.append(mGUI)
+            self.movesLayout.addWidget(mGUI, i, 0)
+            i += 1
 
         # print(self.Engine.currentIndex)
         self.update()

--- a/general_TA_simulator.py
+++ b/general_TA_simulator.py
@@ -64,7 +64,12 @@ class Move(QWidget):
         if self.move["type"] == "a":
             moveText = "Attach\n" +  self.move["state1"].get_label() + " at " + str(self.move["x"]) + " , " + str(self.move["y"])
         elif self.move["type"] == "t":
-            moveText = "Transition\n" + self.move["state1"].get_label() + ", " + self.move["state2"].get_label() + " to " + self.move["state1Final"].get_label() + ", " + self.move["state2Final"].get_label()
+            # Add Transition Direction
+            if self.move["dir"] == "v":
+                moveText = "V "
+            else:
+                moveText = "H "
+            moveText += "Transition\n" + self.move["state1"].get_label() + ", " + self.move["state2"].get_label() + " to " + self.move["state1Final"].get_label() + ", " + self.move["state2Final"].get_label()
 
         qp.setPen(QColor(255,255,255))
         qp.setFont(QFont("Times", 12))

--- a/general_TA_simulator.py
+++ b/general_TA_simulator.py
@@ -71,8 +71,8 @@ class Move(QWidget):
                 moveText = "H "
             moveText += "Transition\n" + self.move["state1"].get_label() + ", " + self.move["state2"].get_label() + " to " + self.move["state1Final"].get_label() + ", " + self.move["state2Final"].get_label()
 
-        qp.setPen(QColor(255,255,255))
-        qp.setFont(QFont("Times", 12))
+        pen = QApplication.palette().text().color()
+        qp.setPen(pen)
         qp.drawText(event.rect(), Qt.AlignCenter, moveText)
         qp.drawRect(event.rect())
     
@@ -413,7 +413,7 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
             # Create moves and add to layout
             for m in self.Engine.validMoves:
                 mGUI = Move(m, self, self.centralwidget)
-                mGUI.setFixedHeight(28)
+                mGUI.setFixedHeight(34)
                 self.moveWidgets.append(mGUI)
                 self.movesLayout.addWidget(mGUI)
 

--- a/general_TA_simulator.py
+++ b/general_TA_simulator.py
@@ -43,8 +43,8 @@ currentAssemblyHistory = []
 # Keep growing until their are no more rules that apply
 
 class Move(QWidget):
-    def __init__(self, move, mw):
-        super().__init__()
+    def __init__(self, move, mw, parent):
+        super().__init__(parent)
         self.move = move
         self.mw = mw
         self.initUI()
@@ -74,13 +74,6 @@ class Move(QWidget):
     def mousePressEvent(self, event):
         self.mw.do_move(self.move)
     
-    # def printMove(move):
-    # if move["type"] == "a":
-    #     print("Attach: ", move["state1"].get_label(), " at ", move["x"], ", ", move["y"])
-    # if move["type"] == "t":
-    #     print("Transition ", move["state1"].get_label(), ", ", move["state2"].get_label(), " to ", move["state1Final"].get_label(), ", ", move["state2Final"].get_label())
-    #     print(" at ", move["x"], ", ", move["y"])
-
 class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
     def __init__(self):
         super().__init__()
@@ -414,7 +407,7 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
         elif not len(self.Engine.validMoves) == 0:
             # Create moves and add to layout
             for m in self.Engine.validMoves:
-                mGUI = Move(m, self)
+                mGUI = Move(m, self, self.centralwidget)
                 mGUI.setFixedHeight(28)
                 self.moveWidgets.append(mGUI)
                 self.movesLayout.addWidget(mGUI)

--- a/general_TA_simulator.py
+++ b/general_TA_simulator.py
@@ -400,12 +400,13 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
 
         # Remove old widgets from the layout
         for m in self.moveWidgets:
+            self.movesLayout.removeWidget(m)
             m.deleteLater()
         self.moveWidgets = []
 
-        # If playing, don't show moves
-        if self.play:
-            status = QLabel("Playing...")
+        # If no more moves, show it
+        if len(self.Engine.validMoves) == 0:
+            status = QLabel("No Available Moves")
             self.moveWidgets.append(status)
             self.movesLayout.addWidget(status)
         
@@ -417,12 +418,6 @@ class Ui_MainWindow(QMainWindow, TAMainWindow.Ui_MainWindow):
                 mGUI.setFixedHeight(28)
                 self.moveWidgets.append(mGUI)
                 self.movesLayout.addWidget(mGUI)
-        
-        # Assembly is terminal, no moves
-        else:
-            status = QLabel("No Available Moves")
-            self.moveWidgets.append(status)
-            self.movesLayout.addWidget(status)
 
         # print(self.Engine.currentIndex)
         self.update()


### PR DESCRIPTION
Add ability to choose the next move from a list of available moves.

Currently does not support going back in the simulation, as the engine keeps a history of moves and will not choose a new move unless there is no history.